### PR TITLE
feat: add negative login, cart, and sorting tests under cypress-practice

### DIFF
--- a/swag_cart.cy.js
+++ b/swag_cart.cy.js
@@ -1,0 +1,26 @@
+import { InventoryPage } from '../pages/InventoryPage';
+import { CartPage } from '../pages/CartPage';
+
+describe('Swag Labs - Cart Management', () => {
+  const inventory = new InventoryPage();
+  const cart = new CartPage();
+
+  beforeEach(() => {
+    cy.login(); // uses your existing login command
+  });
+
+  it('adds and removes a product from cart', () => {
+    inventory.addToCart('Sauce Labs Bike Light');
+    inventory.goToCart();
+
+    cart.item('Sauce Labs Bike Light').should('exist');
+
+    // Remove from cart
+    cy.contains('.cart_item', 'Sauce Labs Bike Light')
+      .find('button')
+      .contains('Remove')
+      .click();
+
+    cart.item('Sauce Labs Bike Light').should('not.exist');
+  });
+});

--- a/swag_login_negativ.cy.js
+++ b/swag_login_negativ.cy.js
@@ -1,0 +1,24 @@
+describe('Swag Labs - Negative Login Scenarios', () => {
+  beforeEach(() => {
+    cy.visit('https://www.saucedemo.com/');
+  });
+
+  it('fails with invalid username', () => {
+    cy.get('[data-test="username"]').type('wrong_user');
+    cy.get('[data-test="password"]').type('secret_sauce', { log: false });
+    cy.get('[data-test="login-button"]').click();
+    cy.get('[data-test="error"]').should('contain.text', 'Username and password do not match');
+  });
+
+  it('fails with invalid password', () => {
+    cy.get('[data-test="username"]').type('standard_user');
+    cy.get('[data-test="password"]').type('wrong_password', { log: false });
+    cy.get('[data-test="login-button"]').click();
+    cy.get('[data-test="error"]').should('contain.text', 'Username and password do not match');
+  });
+
+  it('fails with empty fields', () => {
+    cy.get('[data-test="login-button"]').click();
+    cy.get('[data-test="error"]').should('contain.text', 'Username is required');
+  });
+});

--- a/swag_sort.cy.js
+++ b/swag_sort.cy.js
@@ -1,0 +1,29 @@
+describe('Swag Labs - Product Sorting', () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it('sorts products by Price (low to high)', () => {
+    cy.get('[data-test="product_sort_container"]').select('Price (low to high)');
+
+    let prices = [];
+    cy.get('.inventory_item_price').each(($el) => {
+      prices.push(parseFloat($el.text().replace('$', '')));
+    }).then(() => {
+      const sorted = [...prices].sort((a, b) => a - b);
+      expect(prices).to.deep.equal(sorted);
+    });
+  });
+
+  it('sorts products by Name (Z to A)', () => {
+    cy.get('[data-test="product_sort_container"]').select('Name (Z to A)');
+
+    let names = [];
+    cy.get('.inventory_item_name').each(($el) => {
+      names.push($el.text());
+    }).then(() => {
+      const sorted = [...names].sort().reverse();
+      expect(names).to.deep.equal(sorted);
+    });
+  });
+});


### PR DESCRIPTION
## What
- Added negative login scenarios
- Added add/remove cart test
- Added product sorting tests

## Why
- Expand coverage for training repo
- Practice branch → PR → merge workflow

## How to test
- Run `npx cypress open`
- Execute tests under cypress/e2e/cypress-practice/